### PR TITLE
Fix definition box XPath

### DIFF
--- a/scrapers/urbandictionary.rb
+++ b/scrapers/urbandictionary.rb
@@ -28,7 +28,7 @@ class UrbanDictionary
     doc = Nokogiri::HTML(open(URL + term, 'User-Agent' => UA))
 
     # run the xpath
-    doc.search("/html/body//div[@class='box']")
+    doc.search("//div[@class='def-panel' and @data-defid]")
   end
 
   def parse_definition(term, definition)


### PR DESCRIPTION
It appears Urban Dictionary has updated the page layout; definitions are no longer working: http://urbanscraper.herokuapp.com/define/zomg.

I've modified the XPath to get elements with the `def-panel` class and the `data-defid` attribute.
