### PR TITLE
Added random definition search - needs testing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -43,6 +43,19 @@ get '/' do
 end
 
 #
+#  Fetches a random definition by following the /random.php redirect
+#  and taking out the term with a regexp
+#
+get '/random' do
+  rdef = ud.get_random_definition()
+    unless valid_response? definition
+    raise NoDefinition, params[:term]
+  end
+
+  jsonp definition
+end
+
+#
 # Get the Top Definition for a Term
 #
 get '/define/:term' do

--- a/scrapers/urbandictionary.rb
+++ b/scrapers/urbandictionary.rb
@@ -2,12 +2,16 @@ require 'nokogiri'
 require 'open-uri'
 require 'json'
 require 'date'
+require 'net/http'
+require 'uri'
 
 class UrbanDictionary
   VERSION = '2.1'
   UA = "UrbanScraper/#{VERSION} (http://urbanscraper.herokuapp.com)"
   DOMAIN = 'http://www.urbandictionary.com'
+  RANDOM = '/random.php'
   URL = "#{DOMAIN}/define.php?term="
+  REGEXP = /^.*term=([a-zA-Z ]*)&{0,1}.*|\z/
 
   def get_top_definition(term)
     definitions = fetch_definitions(term)
@@ -19,6 +23,13 @@ class UrbanDictionary
     definitions = fetch_definitions(term)
 
     definitions.map { |m| parse_definition(term, m) }
+  end
+
+  def get_random_definition()
+    uri = URL(DOMAIN+RANDOM)
+    response = Net::HTTP.get_response(uri)
+    matchdata = REGEXP.match(response['Location'])
+    get_top_definition(matchdata[0])
   end
 
   private


### PR DESCRIPTION
Hello!

I'm building a Discord Bot in Go and a friend requested a random definition feature. Since there was no random definition in this API I tried to hack one together.

Since the random feature in UD is done by a redirect we can just follow the `/random.php` and parse the link normally.

What I did after following the request is taking the definition out of the link with a regular expressing and feed the first match to the normal `get_top_definition`.

However I do not have the knowledge to test it, nor to run it in my system since when I try `bundle install` it returns:
`Your Ruby version is 2.4.1, but your Gemfile specified 2.2.4`

I'm sure this is easily fixable (or not) but from searching it's not that simple (at least for me).
This way I submit my idea/code for review in hopes of helping and getting help!

Thank you for your time!

PS: I also suggest adding a `/` to the end of `DOMAIN` since this way it become easier to append things without forgetting the damned `/`