### PR TITLE
Use a proper HTTP client for requests.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 ruby "2.4.3"
 
+gem "faraday"
 gem "nokogiri"
 gem "pygments.rb"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  faraday
   nokogiri
   pry
   pygments.rb
@@ -82,4 +83,4 @@ RUBY VERSION
    ruby 2.4.3p205
 
 BUNDLED WITH
-   1.16.0
+   1.16.3

--- a/scrapers/urbandictionary.rb
+++ b/scrapers/urbandictionary.rb
@@ -1,12 +1,12 @@
 require 'nokogiri'
-require 'open-uri'
+require "faraday"
 require 'json'
 require 'date'
 
 class UrbanDictionary
   VERSION = '2.1'
   UA = "UrbanScraper/#{VERSION} (http://urbanscraper.herokuapp.com)"
-  DOMAIN = 'http://www.urbandictionary.com'
+  DOMAIN = "https://www.urbandictionary.com"
   URL = "#{DOMAIN}/define.php?term="
 
   def get_top_definition(term)
@@ -23,9 +23,17 @@ class UrbanDictionary
 
   private
 
+  def connection
+    connection = Faraday.new(url: DOMAIN)
+    connection.headers[:user_agent] = UA
+
+    connection
+  end
+
   def fetch_definitions(term)
     # pull it into nokogiri
-    doc = Nokogiri::HTML(open(URL + term, 'User-Agent' => UA))
+    response = connection.get("#{URL}#{term}")
+    doc = Nokogiri::HTML(response.body)
 
     # run the xpath
     doc.search("//div[@class='def-panel' and @data-defid]")

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "App" do
           "\"zOMG! you r teh winz!!one!!eleven!\"",
         )
         expect(json_response["url"]).to eq(
-          "http://www.urbandictionary.com/define.php?term=zomg&defid=1401399",
+          "https://www.urbandictionary.com/define.php?term=zomg&defid=1401399",
         )
       end
     end

--- a/spec/cassettes/bad_definition_request.yml
+++ b/spec/cassettes/bad_definition_request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.urbandictionary.com/define.php?term=thvbqgfbhkrvjv
+    uri: https://www.urbandictionary.com/define.php?term=thvbqgfbhkrvjv
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/define.yml
+++ b/spec/cassettes/define.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.urbandictionary.com/define.php?term=zomg
+    uri: https://www.urbandictionary.com/define.php?term=zomg
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/urbandictionary_spec.rb
+++ b/spec/urbandictionary_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe UrbanDictionary do
         expect(definition[:id]).to eq("1401399")
         expect(definition[:term]).to eq("zomg")
         expect(definition[:url]).to eq(
-          "http://www.urbandictionary.com/define.php?term=zomg&defid=1401399",
+          "https://www.urbandictionary.com/define.php?term=zomg&defid=1401399",
         )
         expect(definition[:definition]).to start_with(
           "zOMG is a varient of the all-too-popular acronym",
@@ -19,7 +19,7 @@ RSpec.describe UrbanDictionary do
         )
         expect(definition[:author]).to eq("ectweak")
         expect(definition[:author_url]).to eq(
-          "http://www.urbandictionary.com/author.php?author=ectweak",
+          "https://www.urbandictionary.com/author.php?author=ectweak",
         )
         expect(definition[:posted]).to eq(DateTime.new(2005, 8, 6))
       end


### PR DESCRIPTION
Using `open` is a security risk that's been well known for a while. This
replaces it with Faraday instead.